### PR TITLE
fix(types): `emitEvent` accepts an optional payload

### DIFF
--- a/src/vanilla.ts
+++ b/src/vanilla.ts
@@ -20,6 +20,6 @@ export function offEvent(eventName: string, handler: EventHandler, options?: Eve
 /**
  * Dispatches a payload to listeners for a given event.
  */
-export function emitEvent(eventName: string, payload: any): void {
+export function emitEvent(eventName: string, payload?: any): void {
   eventEmitter.emit(eventName, payload)
 }


### PR DESCRIPTION
Fixes a regression from https://github.com/utsuboco/events/pull/2 where `undefined` and `null` were valid, but not `never`.